### PR TITLE
Start timer on creation

### DIFF
--- a/stopwatch.go
+++ b/stopwatch.go
@@ -45,10 +45,11 @@ type step struct {
 
 // Start creates a profile timer and starts it.
 func NewTimer() *timer {
-	return &timer{
+	t := &timer{
 		now:     time.Now,
-		running: false,
 	}
+	t.Start()
+	return t
 }
 
 // Start starts the stopwatch


### PR DESCRIPTION
It seems like the description mentions it starting the timer on creation but doesn't, this commit hopefully restores the described expected behavior.